### PR TITLE
Solves bug drawing rectangles and dashed lines.

### DIFF
--- a/bgrapen.pas
+++ b/bgrapen.pas
@@ -694,8 +694,15 @@ var
   procedure StartDash(index: integer; t: single);
   begin
     dashStartIndex := index;
-    dashLeftStartPos := leftPts[index] + (leftPts[index+1]-leftPts[index])*t;
-    dashRightStartPos := rightPts[index] + (rightPts[index+1]-rightPts[index])*t;
+    if t = 0 then
+    begin
+      dashLeftStartPos := leftPts[index];
+      dashRightStartPos := rightPts[index];
+    end else
+    begin
+      dashLeftStartPos := leftPts[index] + (leftPts[index+1]-leftPts[index])*t;
+      dashRightStartPos := rightPts[index] + (rightPts[index+1]-rightPts[index])*t;
+    end;
     betweenDash := false;
   end;
 
@@ -799,7 +806,7 @@ begin
     begin
       if len-lenDone < remainingDash then
       begin
-        remainingDash := remainingDash -len-lenDone;
+        remainingDash := remainingDash - (len-lenDone);
         if remainingDash = 0 then NextStyleIndex;
         lenDone := len;
       end else

--- a/geometrytypes.inc
+++ b/geometrytypes.inc
@@ -1065,7 +1065,7 @@ end;
 
 class operator TPointF.NotEqual(const pt1, pt2: TPointF): boolean;
 begin
-  result := (pt1.x <> pt2.x) and (pt1.y <> pt2.y);
+  result := (pt1.x <> pt2.x) or (pt1.y <> pt2.y);
 end;
 
 class operator TPointF.Subtract(const pt1, pt2: TPointF): TPointF;


### PR DESCRIPTION
Hi,

when testing this sample code taken from tutorial, draws a a figure like a triangle. and a shape like a triangle instead of a dotted line.

This patch solves both problems.

`procedure TForm1.Button1Click(Sender: TObject);
var
  image: TBGRABitmap;
  c: TBGRAPixel;
begin
  image := TBGRABitmap.Create(ClientWidth,ClientHeight,ColorToBGRA(ColorToRGB(clBtnFace)));
  c := ColorToBGRA(ColorToRGB(clWindowText));
  image.RectangleAntialias(80,80,300,200,c,10);
  image.PenStyle := psDot;
  image.DrawLineAntialias(20,300,150,300,c,10,true);
  image.Draw(Canvas,0,0,True);
  image.free;
end;
`